### PR TITLE
Support a summary at the top of the report

### DIFF
--- a/src/main/resources/cucumber/formatter/formatter.js
+++ b/src/main/resources/cucumber/formatter/formatter.js
@@ -127,6 +127,18 @@ CucumberHTML.DOMFormatter = function(rootNode) {
       populateStepError($('details', currentElement), after.error_message);
     }
   };
+  
+  this.summary = function(summary) {
+    reportSummary(rootNode, summary)
+  };
+
+  function reportSummary(parent, summary) {
+    var e = $('.summary', $templates).clone();
+    e.prependTo(parent)
+    e.find('.scenario_summary').text(summary.scenarios);
+    e.find('.step_summary').text(summary.steps);
+    e.find('.total_duration').text(summary.duration);
+  }
 
   function featureElement(statement, itemtype) {
     var e = blockElement(currentFeature.children('details'), statement, itemtype);
@@ -211,6 +223,15 @@ CucumberHTML.templates = '<div>\
     <thead></thead>\
     <tbody></tbody>\
   </table>\
+\
+  <section class="summary" itemscope>\
+    <summary class="header">\
+      <span class="keyword" itemprop="keyword">Summary:</span>\
+    </summary>\
+    <div itemprop="scenario_summary" class="scenario_summary summary_item">Scenario summary</div>\
+    <div itemprop="step_summary" class="step_summary summary_item">Steps summary</div>\
+    <div itemprop="total_duration" class="total_duration summary_item">Total duration</div>\
+  </section>\
 \
   <section class="embed">\
     <img itemprop="screenshot" class="screenshot" />\

--- a/src/main/resources/cucumber/formatter/report.js
+++ b/src/main/resources/cucumber/formatter/report.js
@@ -62,6 +62,7 @@ for(var n = 0; n < N; n++) {
   formatter.match({uri:'report.feature'});
   formatter.result({status:'failed', error_message:'I didn\'t do it.', duration: 0});
   formatter.after({status: 'failed', duration: 668816288, "error_message": 'com.example.MyDodgyException: Widget underflow\r\n\tat org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:264)\r\n\tat com.example.WidgetFurbicator.furbicateWidgets(WidgetFurbicator.java:678)'});
+  formatter.summary({scenarios: '2 Scenarios (2 failed)', steps: '9 Steps (2 failed, 1 undefined, 1 skipped, 5 passed)', duration: '0m1.023s'});
 }
 console.log('Rendered %s features in %s ms', N, new Date().getTime() - start);
 

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -11,6 +11,10 @@
   margin-left: 20px;
 }
 
+.cucumber-report .summary_item {
+  margin-left: 20px;
+}
+
 .cucumber-report details > section {
   margin-left: 20px;
 }


### PR DESCRIPTION
This PR fixes #8 and is a prerequisite for implementing https://github.com/cucumber/cucumber-jvm/issues/292 so the HTMLFormatter in Cucumber-JVM actually inserts the summary data in the HTML report. The calculation of the summary data is implemented in Cucumber-JVM by https://github.com/cucumber/cucumber-jvm/pull/536.

HTML + CCS + JS are a little bit out of my comfort zone, but this seems to me as something like "the simplest thing that could possible work".
