### PR TITLE
updated styling to look more like ruby output and added a summary header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 /.project
 /.classpath
 /.settings
-.idea
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.classpath
 /.settings
+.idea
+*.iml

--- a/src/main/resources/cucumber/formatter/formatter.js
+++ b/src/main/resources/cucumber/formatter/formatter.js
@@ -20,7 +20,7 @@ CucumberHTML.DOMFormatter = function(rootNode) {
   // Draw initial summary
   (function()
   {
-    $('.cucumber-report').append( '<div id="cucumber-header"><div id="label"><h1>Neo Cucumber Acceptance Testing</h1></div><div id="summary"><p id="totals"></p><p id="duration"></div>' );
+    $('.cucumber-report').append( '<div id="cucumber-header"><div id="label"><h1>Cucumber Features</h1></div><div id="summary"><p id="totals"></p><p id="duration"></div>' );
   })();
 
   function updateTotals() {
@@ -129,7 +129,11 @@ CucumberHTML.DOMFormatter = function(rootNode) {
 
       updateTotals();
 
-      currentElement.find('details').attr('open', 'open');
+      if (result.status != 'passed') {
+        currentElement.find('details').attr('open', 'open');
+      } else {
+        currentElement.find('details').removeAttr('open');
+      }
     }
   };
 

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -165,6 +165,11 @@ body {
   background-color:  #2DEAEC;
 }
 
+.undefined .header {
+  color: #000;
+  background-color: #EAEC2D;
+}
+
 .failed .header {
   background: rgb(196, 13, 13);
 }

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -1,7 +1,7 @@
 body {
-  font-size: 0px;
-  margin: 0px;
-  padding: 0px;
+  font-size: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .cucumber-report {
@@ -33,13 +33,11 @@ body {
 
 .cucumber-report table {
   border-collapse: collapse;
-  border: 1px;
-  border-style: solid;
+  border: 1px solid;
 }
 
 .cucumber-report td, .cucumber-report th {
-  border: 1px;
-  border-style: solid;
+  border: 1px solid;
   padding-left: 4px;
   padding-right: 4px;
 }
@@ -82,6 +80,7 @@ body {
   font-size: 11px;
   background: #fffbd3;
   color: black;
+  overflow-x: auto;
 }
 
 #cucumber-templates {
@@ -127,8 +126,7 @@ body {
 
 .step {
   margin: 5px;
-  padding: 3px;
-  padding-left: 18px;
+  padding: 3px 3px 3px 18px;
   font-size: 11px;
 }
 
@@ -189,14 +187,14 @@ img {
 }
 
 h1 {
-  margin: 0px 10px;
+  margin: 0 10px;
   padding: 10px;
 }
 
 #summary {
   text-align: right;
   float: right;
-  padding: 0px 10px;
+  padding: 0 10px;
 }
 
 #cucumber-header {

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -181,6 +181,7 @@ body {
 img {
   margin-top: 10px;
   display:block;
+  max-width: 100%;
 }
 
 #label {

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -1,14 +1,15 @@
-.cucumber-report .body {
-  font-family: Helvetica,Arial,sans-serif;
+body {
+  font-size: 0px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.cucumber-report {
+  font: normal 12px "Lucida Grande", Helvetica, sans-serif;
 }
 
 .cucumber-report .keyword {
   font-weight: bold;
-}
-
-.cucumber-report .description {
-  font-style: italic;
-  margin-left: 20px;
 }
 
 .cucumber-report details > section {
@@ -18,7 +19,8 @@
 .cucumber-report ol.steps {
   list-style-type: none;
   margin-top: 0;
-  margin-bottom: 0;
+  margin-bottom: 1.5em;
+  padding-left: 5px;
 }
 
 .cucumber-report .step .embedded-text {
@@ -50,24 +52,13 @@
   background-color: #C0C0C0;
 }
 
-.cucumber-report .passed {
-  background-color: #C5D88A;
-}
-
 .cucumber-report .undefined, .cucumber-report .pending {
   background-color: #EAEC2D;
 }
 
-.cucumber-report .skipped {
-  background-color: #2DEAEC;
-}
-
-.cucumber-report .failed {
-  background-color: #D88A8A;
-}
-
 .cucumber-report .tags {
-  display: inline;
+  /*display: none;*/
+  float:right;
 }
 
 .cucumber-report .tag {
@@ -88,9 +79,126 @@
   margin: .2em .75em;
   padding: .2em;
   border: 1px solid #900;
-  background-color: #EDBBBB;
+  font-size: 11px;
+  background: #fffbd3;
+  color: black;
 }
 
 #cucumber-templates {
   display: none;
+}
+
+.description {
+  white-space: pre;
+  font-size: 12px;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  margin-left: 20px;
+}
+
+.header {
+  font-weight: bold;
+  padding: 3px;
+}
+
+.feature .header {
+  font-size: 1.5em;
+}
+
+.scenario .header {
+  font-size: 12px;
+}
+
+.background .header {
+  font-size: 12px;
+}
+
+.after .header {
+  font-size: 12px;
+}
+
+.scenario_outline .header {
+  font-size: 12px;
+}
+
+.passed .header {
+  background-color: #65c400;
+}
+
+.step {
+  margin: 5px;
+  padding: 3px;
+  padding-left: 18px;
+  font-size: 11px;
+}
+
+.passed.step {
+  background-color: #dbffb4;
+  border-left: 5px solid #65c400;
+  border-bottom: 1px solid #65c400;
+  color: #3d7700;
+}
+
+.failed.step {
+  border-left: 5px solid #c20000;
+  border-bottom: 1px solid #c20000;
+  background: #fffbd3;
+  color: #c20000;
+}
+
+.skipped.step {
+  border-left: 5px solid aqua;
+  border-bottom: 1px solid aqua;
+  background: #e0ffff;
+  color: #001111;
+}
+
+.scenario .header {
+  color: white;
+}
+.background .header {
+  color: white;
+  background-color: #666;
+}
+
+.skipped .header {
+  background-color:  #2DEAEC;
+}
+
+.failed .header {
+  background: rgb(196, 13, 13);
+}
+
+.feature {
+  margin-top: 3em;
+}
+
+img {
+  margin-top: 10px;
+  display:block;
+}
+
+#label {
+  position: absolute;
+}
+
+h1 {
+  margin: 0px 10px;
+  padding: 10px;
+}
+
+#summary {
+  text-align: right;
+  float: right;
+  padding: 0px 10px;
+}
+
+#cucumber-header {
+  color: white;
+  height: 6em;
+  background-color: #65c400;
+}
+
+#cucumber-header.failed {
+  background-color: rgb(196, 13, 13);
 }

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -71,8 +71,8 @@ body {
 }
 
 .cucumber-report .comment {
-  margin 0;
-  padding 0;
+  margin: 0;
+  padding: 0;
 }
 
 .cucumber-report .error {


### PR DESCRIPTION
As suggested by Seb in https://groups.google.com/forum/#!topic/cukes/4qO6FpkjNiA I created a pull request.
This is far from perfect code, but it makes the output look a lot better than it was, without needing to change the generated 'report.js'.

What it does:
- Makes the report look more like the ruby report
- Added a header with a summary (title, number of steps and scenarios, duration).
