### PR TITLE
Highlight arguments in html report

### DIFF
--- a/src/main/resources/cucumber/formatter/formatter.js
+++ b/src/main/resources/cucumber/formatter/formatter.js
@@ -34,9 +34,7 @@ CucumberHTML.DOMFormatter = function(rootNode) {
   };
 
   this.step = function(step) {
-    if (step.arguments) {
-      highlightArguments(step);
-    }
+    highlightArguments(step);
 
     var stepElement = $('.step', $templates).clone();
     stepElement.appendTo(currentSteps);
@@ -63,10 +61,19 @@ CucumberHTML.DOMFormatter = function(rootNode) {
 
   function highlightArguments(step) {
     var textArray = step.name.split('');
-    $.each(step.arguments, function(index, arg) {
-      textArray[arg.start] = '<span class="argument">' + textArray[arg.start];
-      textArray[arg.end] = '</span>' + (textArray[arg.end] ? textArray[arg.end] : '');
+    textArray = $.map(textArray, function (char) {
+      if (char === '<') return '&lt;';
+      if (char === '>') return '&gt;';
+      if (char === '&') return '&amp;';
+      return char;
     });
+
+    if (step.arguments) {
+      $.each(step.arguments, function(index, arg) {
+        textArray[arg.start] = '<span class="argument">' + textArray[arg.start];
+        textArray[arg.end] = '</span>' + (textArray[arg.end] ? textArray[arg.end] : '');
+      });
+    }
     step.name = textArray.join('');
   }
 

--- a/src/main/resources/cucumber/formatter/formatter.js
+++ b/src/main/resources/cucumber/formatter/formatter.js
@@ -34,6 +34,10 @@ CucumberHTML.DOMFormatter = function(rootNode) {
   };
 
   this.step = function(step) {
+    if (step.arguments) {
+      highlightArguments(step);
+    }
+
     var stepElement = $('.step', $templates).clone();
     stepElement.appendTo(currentSteps);
     populate(stepElement, step, 'step');
@@ -56,6 +60,15 @@ CucumberHTML.DOMFormatter = function(rootNode) {
       });
     }
   };
+
+  function highlightArguments(step) {
+    var textArray = step.name.split('');
+    $.each(step.arguments, function(index, arg) {
+      textArray[arg.start] = '<span class="argument">' + textArray[arg.start];
+      textArray[arg.end] = '</span>' + (textArray[arg.end] ? textArray[arg.end] : '');
+    });
+    step.name = textArray.join('');
+  }
 
   this.examples = function(examples) {
     var examplesElement = blockElement(currentElement.children('details'), examples, 'examples');
@@ -170,7 +183,7 @@ CucumberHTML.DOMFormatter = function(rootNode) {
     populateTags(e, statement.tags);
     populateComments(e, statement.comments);
     e.find('.keyword').text(statement.keyword);
-    e.find('.name').text(statement.name);
+    e.find('.name').html(statement.name);
     e.find('.description').text(statement.description);
     e.attr('itemtype', 'http://cukes.info/microformat/' + itemtype);
     e.addClass(itemtype);

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -6,6 +6,10 @@
   font-weight: bold;
 }
 
+.cucumber-report .argument {
+  font-weight: bold;
+}
+
 .cucumber-report .description {
   font-style: italic;
   margin-left: 20px;


### PR DESCRIPTION
This highlights the arguments of the steps in the HTML report, displaying them in bold.

There's a corresponding pull request against cucumber-jvm (https://github.com/cucumber/cucumber-jvm/pull/1452) that includes the argument information in the .js report.